### PR TITLE
Release 0.5.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # JavaScript dependencies
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      # Keep minor and patch bumps in a single PR, major bumps stay separate
+      # so they can be handled in a dedicated release
+      npm-minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # Rust dependencies, the Tauri backend lives in src-tauri
+  - package-ecosystem: 'cargo'
+    directory: '/src-tauri'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # Actions used by the test and release workflow
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -26,10 +26,12 @@ jobs:
         run: |
           echo "Building and running the app..."
           npm run build
+      # Retries stay enabled so the report tells a flaky test apart from a hard failure,
+      # but a test that needed a retry now fails the job instead of reporting green
       - name: Run Playwright tests
         run: |
           echo "Running Playwright tests..."
-          npm run test:e2e
+          npm run test:e2e -- --fail-on-flaky-tests
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -10,8 +10,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "Running Playwright tests..."
           npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -42,8 +42,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Audit npm dependencies
@@ -51,7 +51,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo-audit binary
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-${{ runner.os }}
@@ -72,8 +72,8 @@ jobs:
       release_id: ${{ steps.create-release.outputs.result }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: create release
         id: create-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BODY_CONTENT: |
             Take a look at the assets to download and install this app for GCP emulators v`${process.env.PACKAGE_VERSION}`
@@ -124,10 +124,10 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
 
@@ -153,7 +153,7 @@ jobs:
       - name: install frontend dependencies
         run: npm install # change this to npm or pnpm depending on which one you use
 
-      - uses: tauri-apps/tauri-action@v0.5.20
+      - uses: tauri-apps/tauri-action@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -169,7 +169,7 @@ jobs:
     steps:
       - name: publish release
         id: publish-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           release_id: ${{ needs.create-release.outputs.release_id }}
         with:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -37,10 +37,34 @@ jobs:
           path: playwright-report/
           retention-days: 1
 
-  # Create a release when a tag is pushed, tests must succeed
+  # Audit npm and Rust dependencies against known security advisories
+  security-audit:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Audit npm dependencies
+        run: npm audit --audit-level=high
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo-audit binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Audit Rust dependencies
+        working-directory: src-tauri
+        run: cargo audit
+
+  # Create a release when a tag is pushed, tests and security audit must succeed
   create-release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: run-tests
+    needs: [run-tests, security-audit]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -54,9 +54,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-audit
-          key: cargo-audit-${{ runner.os }}
+          key: cargo-audit-v1-${{ runner.os }}
+      # Skip the build when the cached binary was restored: cargo install refuses to
+      # overwrite a binary it holds no install record for. The advisory database is
+      # fetched at run time, so a cached binary still audits against fresh advisories.
+      # Bump the cache key above to rebuild cargo-audit itself.
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: command -v cargo-audit > /dev/null || cargo install cargo-audit --locked
       - name: Audit Rust dependencies
         working-directory: src-tauri
         run: cargo audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.8] - 2026-08-23
+
+- Add a security audit job to the CI, blocking the release chain (npm audit and cargo audit)
+- Add a Dependabot configuration for weekly npm, Cargo and GitHub Actions updates
+- Update @tanstack/react-query to 5.102.1 and react-hook-form to 7.86.0
+- Update Rust dependencies (cc, crc32fast, icu_provider, log, swift-rs, uuid, zerovec-derive)
+
+Maintenance release: no security advisory was open at the time of writing. npm audit,
+cargo audit and Dependabot all reported zero open vulnerabilities.
+
 ## [0.5.7] - 2026-08-20
 
 - Fix 8 npm security vulnerabilities (react-router, vite, postcss, js-yaml, nanoid, brace-expansion, @babel/core)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update every GitHub Action to a Node.js 24 runtime, clearing the Node.js 20 deprecation
   warnings (checkout 7, setup-node 7, upload-artifact 7, github-script 9, cache 6,
   tauri-action 1.0.0)
+- Fail the CI on flaky tests, a test passing only on retry no longer reports green
+- Fix the flaky schema creation E2E test, its alert locator matched both the form success
+  alert and the empty list alert
 - Update @tanstack/react-query to 5.102.1 and react-hook-form to 7.86.0
 - Update Rust dependencies (cc, crc32fast, icu_provider, log, swift-rs, uuid, zerovec-derive)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add a security audit job to the CI, blocking the release chain (npm audit and cargo audit)
 - Add a Dependabot configuration for weekly npm, Cargo and GitHub Actions updates
+- Update every GitHub Action to a Node.js 24 runtime, clearing the Node.js 20 deprecation
+  warnings (checkout 7, setup-node 7, upload-artifact 7, github-script 9, cache 6,
+  tauri-action 1.0.0)
 - Update @tanstack/react-query to 5.102.1 and react-hook-form to 7.86.0
 - Update Rust dependencies (cc, crc32fast, icu_provider, log, swift-rs, uuid, zerovec-derive)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
         "@mui/material": "7.3.11",
         "@mui/x-data-grid": "8.29.2",
         "@tailwindcss/vite": "4.3.3",
-        "@tanstack/react-query": "5.101.4",
+        "@tanstack/react-query": "5.102.1",
         "@tauri-apps/api": "2.11.1",
         "@tauri-apps/plugin-shell": "2.3.5",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-hook-form": "7.85.0",
+        "react-hook-form": "7.86.0",
         "react-router-dom": "7.18.2",
         "react-syntax-highlighter": "16.1.1",
         "tailwindcss": "4.3.3"
@@ -1659,9 +1659,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
-      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "version": "5.102.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.1.tgz",
+      "integrity": "sha512-bJTsrO2ODWSgg+x1leTsK036GBtmNNjnrF1Vk06J5fg/phYZLQIdXrBe0uf5xTItXYvIW1MtbLhyPw7cPMqUUQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1669,12 +1669,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
-      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "version": "5.102.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.102.1.tgz",
+      "integrity": "sha512-DKJeRvxjsGUWhUVnVVXSseTS0SKBMLSkrz8dm7i08r93IQQ2gAfUkX1e801gVZ18KSwHiG5yng4tQm5+qSGS0w==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.4"
+        "@tanstack/query-core": "5.102.1"
       },
       "funding": {
         "type": "github",
@@ -5658,9 +5658,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.85.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.85.0.tgz",
-      "integrity": "sha512-U2MTriFXnclmV4rOE20p2DcRFv5WEg3FIcBFOKcOLFHDVvGIMPvLTkTWefUsonmlaVy23khVDxDWym6uJVGOzw==",
+      "version": "7.86.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.86.0.tgz",
+      "integrity": "sha512-4kbWJrh5jPZt1+YqVcXcGKffGcXV/XVbozknLh0Yjh0KhpoAkus21TAQhzRYqNwFkkObmnSvRlZZ3GT+ehoIrA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gcp-emulator-gui",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -22,12 +22,12 @@
     "@mui/material": "7.3.11",
     "@mui/x-data-grid": "8.29.2",
     "@tailwindcss/vite": "4.3.3",
-    "@tanstack/react-query": "5.101.4",
+    "@tanstack/react-query": "5.102.1",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-shell": "2.3.5",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-hook-form": "7.85.0",
+    "react-hook-form": "7.86.0",
     "react-router-dom": "7.18.2",
     "react-syntax-highlighter": "16.1.1",
     "tailwindcss": "4.3.3"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "App_for_GCP_emulators"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1456,9 +1456,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1798,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "markup5ever"
@@ -3020,9 +3020,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swift-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7"
+checksum = "e45c444e496845d3f2a351146bff59aae4975b2280238df1dfaa0c7d1846f38e"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -3842,9 +3842,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4692,9 +4692,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "App_for_GCP_emulators"
-version = "0.5.7"
+version = "0.5.8"
 description = "App for GCP emulators"
 authors = ["Fabien Dosse"]
 license = "GPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "App for GCP emulators",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "identifier": "com.app-for-gcp-emulators.dev",
   "plugins": {},
   "app": {

--- a/tests/e2e/pubsub.schema.spec.ts
+++ b/tests/e2e/pubsub.schema.spec.ts
@@ -26,8 +26,10 @@ test.describe('PubSub Schema', () => {
     await page.locator('form #definition').fill('{"type": "record", "name": "test", "fields": [{"name": "field1", "type": "string"}]}');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
 
-    // Verify the schema is created
-    const alert = page.getByRole('alert');
+    // Verify the schema is created. Scope the alert to the form: the list renders its
+    // own "No Schemas" alert, which stays on screen until the list refetch completes,
+    // so an unscoped getByRole('alert') matches two elements and fails on strict mode.
+    const alert = page.locator('form#schema_create').getByRole('alert');
     await expect(alert).toHaveText('Schema created');
     // Should see the new schema in the list
     const schemaRow = page.getByRole('row', { name: 'test-schema projects/project_schema' });


### PR DESCRIPTION
## Contexte

Aucune CVE n'était ouverte au moment de préparer cette release. Vérifié sur trois sources :

| Source | Résultat |
|---|---|
| `npm audit` | 0 vulnérabilité |
| `cargo audit` (src-tauri) | 0 vulnérabilité, 17 warnings `unmaintained` transitifs via Tauri |
| API Dependabot | 0 alerte `open` (78 `fixed`, 1 `dismissed`) |

La 0.5.7 avait fermé les 6 dernières alertes, dont `nanoid` GHSA-2v37-7h3g-55p8. C'est donc une release de maintenance, dont l'apport principal est le durcissement du CI.

## Changements

**CI — audit de sécurité bloquant**
Le workflow ne lançait aucun audit : les CVE se découvraient à la main dans l'onglet Security. Ajout d'un job `security-audit` (`npm audit --audit-level=high` + `cargo audit`), avec `create-release` qui en dépend désormais — aucune release ne sort avec un advisory connu.

**Configuration Dependabot**
`.github/dependabot.yml` n'existait pas ; Dependabot ne faisait que du *security update* implicite, et son run `cargo` était cassé depuis avril 2026. Trois écosystèmes en hebdomadaire : npm, Cargo (`/src-tauri`) et GitHub Actions — cette dernière n'était jamais mise à jour. Les bumps mineurs et patch sont groupés, les majeurs restent séparés pour une 0.6.0 dédiée.

**Dépendances**
- `@tanstack/react-query` 5.101.4 → 5.102.1, `react-hook-form` 7.85.0 → 7.86.0
- Rust : `cc`, `crc32fast`, `icu_provider`, `log`, `swift-rs`, `uuid`, `zerovec-derive`
- Aucune version majeure (ESLint 10, TypeScript 7, MUI 9, x-data-grid 9, `@types/node` 26 sont disponibles mais réservées à une 0.6.0)
- `google/cloud-sdk:581.0.0-emulators` est déjà la dernière image, inchangée

## Vérification

- `npm run lint` — exit 0
- `npm run build` — exit 0
- `npm run test:e2e` — **27/27 passés**
- `npm audit --audit-level=high` — exit 0
- `cargo audit` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)