### PR TITLE
Stop Dependabot from opening major version PRs for npm and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,18 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 5
     groups:
-      # Keep minor and patch bumps in a single PR, major bumps stay separate
-      # so they can be handled in a dedicated release
+      # Keep minor and patch bumps in a single PR
       npm-minor-and-patch:
         update-types:
           - 'minor'
           - 'patch'
+    ignore:
+      # Major bumps belong to a dedicated release, not to a maintenance one, and each
+      # one opened its own failing PR. update-types only filters version updates, so a
+      # security fix that only ships in a major still reaches us as a security update.
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   # Rust dependencies, the Tauri backend lives in src-tauri
   - package-ecosystem: 'cargo'
@@ -25,8 +31,14 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
-  # Actions used by the test and release workflow
+  # Actions used by the test and release workflow. Majors stay enabled here: they are
+  # rare, and they carry the runner deprecations that silently pile up otherwise, as
+  # the Node.js 20 to 24 migration showed.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Contexte

La première exécution hebdomadaire de Dependabot, activée par la 0.5.8, a ouvert cinq PR de montée de version **majeure** — ESLint 10, MUI 9, `@mui/x-data-grid` 9 — dont la plupart ont échoué au CI. C'est le comportement attendu pour des majeures, mais ce sont précisément celles qu'on avait écartées de la ligne de maintenance 0.5.x pour les réserver à une 0.6.0. Les cinq PR ont été fermées manuellement (#50 à #54).

## Changement

Ajout d'une condition `ignore` sur `version-update:semver-major` pour les écosystèmes **npm** et **Cargo**. Les bumps mineurs et patch continuent d'arriver groupés, comme avant.

## Ce qui n'est pas filtré, et pourquoi

**Les mises à jour de sécurité passent toujours.** La documentation GitHub est explicite : `update-types` ne filtre que les *version updates*, pas les *security updates*. Une CVE dont le correctif n'existe que dans une majeure ouvrira donc quand même sa PR. Et le job `security-audit`, bloquant depuis la 0.5.8, la détecterait de toute façon.

**Les majeures d'actions GitHub restent activées.** Elles sont rares, et ce sont elles qui portent les dépréciations de runtime — c'est exactement ce qui a laissé les actions en Node.js 20 s'accumuler jusqu'à la migration vers Node.js 24. Les filtrer reviendrait à recréer l'angle mort qu'on vient de fermer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)